### PR TITLE
#52: Fix backspace reading in raw terminal mode for simulator build

### DIFF
--- a/apps/console_app/console_main.c
+++ b/apps/console_app/console_main.c
@@ -354,7 +354,7 @@ int console_main(int argc, char **argv)
       }
       len = 0;
     }
-    else if (*(cmd_buffer + len - 1) == '\b')
+    else if (*(cmd_buffer + len - 1) == '\b' || *(cmd_buffer + len - 1) == 127)
     {
       if (len > 1) {
         len-=2;

--- a/arch/sim/sim/host_board_up.c
+++ b/arch/sim/sim/host_board_up.c
@@ -133,13 +133,17 @@ static void host_simulated_intterupts(void *arg)
   int ret;
   char c;
 
-  while (1) {
-    ret = read(0, &g_lpuart_fifo[0], sizeof(c));
-    if (ret < 0) {
-      _err("%d read from stdin\n", ret);
+  while (read(STDIN_FILENO, &c, 1) == 1) {
+#if 0 /* Enable this section for debug */
+    if (iscntrl(c)) {
+      printf("%d", c);
     } else {
-      kill(g_host_pid, SIGUSR2);
+      printf("%d ('%c')", c, c);
     }
+#endif
+
+    g_lpuart_fifo[0] = c;
+    kill(g_host_pid, SIGUSR2);
   }
 }
 


### PR DESCRIPTION
### Summary of Changes ###
#52 
In simulator build the terminal does not interpret the backspace character. Because of this we can't delete wrong supplied commands entered in the console.

Signed-off-by: Sebastian Ene <sebastian.ene07@gmail.com>