### PR TITLE
#54 Bugfix : The simulated UART drops characters

### DIFF
--- a/arch/sim/sim/board_uart.c
+++ b/arch/sim/sim/board_uart.c
@@ -29,7 +29,7 @@ static void sim_lpuart_int(void);
  * Public Data
  ****************************************************************************/
 
-uint8_t g_lpuart_fifo[CONFIG_SIM_LPUART_FIFO_SIZE];
+sim_uart_peripheral_t g_uart_peripheral;
 
 /****************************************************************************
  * Private Data
@@ -174,12 +174,17 @@ static void sim_lpuart_int(void)
 {
   struct uart_lower_s *lower = &g_uart_lowerhalfs[0];
 
-  lower->rx_buffer[lower->index_write_rx_buffer] = g_lpuart_fifo[0];
-  lower->index_write_rx_buffer = (lower->index_write_rx_buffer + 1) % UART_RX_BUFFER;
+  if (g_uart_peripheral.uart_reg_read_index != g_uart_peripheral.uart_reg_write_index) {
 
-  /* Notify incomming RX characters */
+    lower->rx_buffer[lower->index_write_rx_buffer] = g_uart_peripheral.sim_uart_data_fifo[g_uart_peripheral.uart_reg_read_index];
+    g_uart_peripheral.uart_reg_read_index = (g_uart_peripheral.uart_reg_read_index + 1) % CONFIG_SIM_LPUART_FIFO_SIZE;
 
-  sem_post(&lower->rx_notify);
+    lower->index_write_rx_buffer = (lower->index_write_rx_buffer + 1) % UART_RX_BUFFER;
+
+    /* Notify incomming RX characters */
+
+    sem_post(&lower->rx_notify);
+  }
 }
 
 /****************************************************************************

--- a/arch/sim/sim/include/simulator.h
+++ b/arch/sim/sim/include/simulator.h
@@ -5,7 +5,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define CONFIG_SIM_LPUART_FIFO_SIZE   (1)
+#define CONFIG_SIM_LPUART_FIFO_SIZE   (32)
 
 /****************************************************************************
  * Public Types
@@ -17,6 +17,14 @@ typedef enum {
   UART_0_IRQ   = 0,
   NUM_IRQS
 } IRQn_Type;
+
+/* The simulated UART peripheral */
+
+typedef struct {
+  uint8_t sim_uart_data_fifo[CONFIG_SIM_LPUART_FIFO_SIZE];
+  uint8_t uart_reg_read_index;  /* The read index is incremented when we read data from the FIFO */
+  uint8_t uart_reg_write_index; /* The write index is incremented when we put data in the FIFO */
+} sim_uart_peripheral_t;
 
 /****************************************************************************
  * Public Functions Definitions


### PR DESCRIPTION
Create a ring buffer that is shared between the host and the simulator
thread. This ring buffer will hold the UART characters as received in
the host thread. After we receive one character we send a signal to the
simulator thread to notify it about the new data. The data will be
receive on the simulator thread in the UART interrupt handler and it
will be copied in the lower half buffer.

Signed-off-by: Sebastian Ene <sebastian.ene07@gmail.com>