### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,11 @@ jobs:
     - name: configure_sim
       run: make config MACHINE_TYPE=sim
     - name: make
-      run: make && pip install -r requirements.txt && python tests/py_test/simulator_cmds.py
+      run: |
+        make
+        pip3 install setuptools
+        pip3 install -r requirements.txt
+        python3 tests/py_test/simulator_cmds.py
     - name: make distcheck
       run: make distclean
     - name: configure_nrf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-fuzzywuzzy==0.18.0
-python-Levenshtein==0.12.0
+rapidfuzz==0.9.1

--- a/tests/py_test/nbstreamreader.py
+++ b/tests/py_test/nbstreamreader.py
@@ -3,7 +3,7 @@
 #
 
 from threading import Thread
-from Queue import Queue, Empty
+from queue import Queue, Empty
 
 class NonBlockingStreamReader:
 

--- a/tests/py_test/simulator_cmds.py
+++ b/tests/py_test/simulator_cmds.py
@@ -2,8 +2,8 @@ import subprocess
 from nbstreamreader import NonBlockingStreamReader as NBSR
 import json
 from difflib import SequenceMatcher
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 
 def send_cmd_wait_response(proc, cmd, nbsr):
     proc.stdin.write(cmd)
@@ -37,7 +37,7 @@ def run_json_cmd_check(proc, nbsr, json_test):
             #print 'Expected:', distro['expected']
 
             #m = SequenceMatcher(None, distro['expected'], output)
-            diffRatio = fuzz.partial_ratio(str(distro['expected']), output)
+            diffRatio = fuzz.partial_ratio(str(distro['expected']), output, score_cutoff=60)
 
             #print "Result matches: " + str(diffRatio)
 

--- a/tests/py_test/simulator_cmds.py
+++ b/tests/py_test/simulator_cmds.py
@@ -48,10 +48,10 @@ def run_json_cmd_check(proc, nbsr, json_test):
                 break
 
         if not isTestPassed:
-            print "[Test_" + str(testNum) + "] FAILED"
-            print "Differs:" + output + " expected:" + distro['expected']
+            print("[Test_" + str(testNum) + "] FAILED")
+            print("Differs:" + output + " expected:" + distro['expected'])
         else:
-            print "[Test_" + str(testNum) + "] PASSED"
+            print("[Test_" + str(testNum) + "] PASSED")
 
         testNum = testNum + 1
 
@@ -62,7 +62,7 @@ proc = subprocess.Popen(run_cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 try:
     nbsr = NBSR(proc.stdout)
     run_json_cmd_check(proc, nbsr, 'tests/py_test/test_cmds/test_console_cmds.txt')
-except Exception, e:
+except Exception as e:
     print("Something went wrong: " + str(e))
 finally:
     proc.kill()


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy