### PR TITLE
Update ESP32 memory layout and fix the booting process

### DIFF
--- a/config/xtensa/esp32dev/release/defconfig
+++ b/config/xtensa/esp32dev/release/defconfig
@@ -9,7 +9,7 @@
 CONFIG_MACHINE_TYPE="lx6"
 CONFIG_MACHINE_CPU="xtensa"
 CONFIG_PREFIX_TOOLCHAIN="xtensa-esp32-elf-"
-CONFIG_COMMAND_LOAD="esptool.py --chip esp32 elf2image --flash_mode dio --flash_size 4MB -o calypso.bin build/build.elf && esptool.py --chip esp32 --port /dev/ttyUSB0 write_flash  0x10000 calypso.bin"
+CONFIG_COMMAND_LOAD="esptool.py --chip esp32 elf2image --flash_mode dio --flash_size 4MB -o calypso.bin build/build.elf && esptool.py --chip esp32 --port /dev/ttyUSB0 write_flash  0x1000 calypso.bin"
 CONFIG_CFLAGS="-fno-strict-aliasing -fdata-sections -ffunction-sections -Os -g -Wall -nostdlib -nostartfiles -mlongcalls -mtext-section-literals -fstrict-volatile-bitfields"
 CONFIG_LDFLAGS=" ${CFLAGS} -Wl,-T${TOPDIR}/config/xtensa/esp32dev/scripts/linker.ld "
 # CONFIG_SPI_0 is not set

--- a/config/xtensa/esp32dev/scripts/linker.ld
+++ b/config/xtensa/esp32dev/scripts/linker.ld
@@ -3,10 +3,7 @@ ENTRY( _start );
 /* Specify main memory areas */
 MEMORY
 {
-  /* Use values from the ESP-IDF 'bootloader' component.
-  /* TODO: Use human-readable lengths */
-  /* TODO: Use the full memory map - this is just a test */
-  iram_seg ( RX )       : ORIGIN = 0x40080680, len = 0xFC00
+  iram_seg ( RX )       : ORIGIN = 0x40098000, len = 0xFC00
   dram_seg ( RW )       : ORIGIN = 0x3FFF0000, len = 0xFFFF
 }
 


### PR DESCRIPTION
     ### Summary of Changes ###
    
    The ESP32 board has a two-stage booting process. In the first stage it
    executes the code from ROM and it copies from the flash at address
    0x1000 the second stage bootloader. Calypso OS will load as part of the
    second stage bootloader at address 0x40098000 in RAM.
    
Signed-off-by: Sebastian Ene <sebastian.ene07@gmail.com>