### PR TITLE
arch/sim: On OSX the ucontext stack for the makecontext(..) is specif…

### DIFF
--- a/arch/sim/sim/board_initialize.c
+++ b/arch/sim/sim/board_initialize.c
@@ -157,8 +157,11 @@ int up_initial_task_context(struct tcb_s *tcb, int argc, char **argv)
   /* When the task has done running it should be chainned to jump to a new
    * ucontext structure.
    */
-
-  task_context->uc_stack.ss_sp    = tcb->stack_ptr_top;// + stack_size;
+#ifdef __APPLE__
+  task_context->uc_stack.ss_sp    = tcb->stack_ptr_base;
+#else
+  task_context->uc_stack.ss_sp    = tcb->stack_ptr_top;
+#endif
   task_context->uc_stack.ss_size  = stack_size;
   task_context->uc_stack.ss_flags = 0;
 


### PR DESCRIPTION

## Summary of changes 

Fix a stack overflow issue on OSX simulation. The ucontext stack pointer is specified from bottom
(lower address) when we create a new context using the makecontext(..) function on OSX.

Signed-off-by: Sebastian Ene <sebastian.ene07@gmail.com>