### PR TITLE
arch/all: Add task name in TCB and dump hardfault registers for nrf5x

### DIFF
--- a/apps/console_app/console_main.c
+++ b/apps/console_app/console_main.c
@@ -225,7 +225,10 @@ static int execute_command(int argc, const char *argv[])
         else
           return sched_create_task((
             int (*)(int, char **))g_cmd_table[j].cmd_function,
-            g_cmd_table[j].stack_size, argc, (char **)argv);
+            g_cmd_table[j].stack_size,
+            argc,
+            (char **)argv,
+            g_cmd_table[j].cmd_name);
 #else
         return g_cmd_table[j].cmd_function(argc, argv);
 #endif /* CONFIG_RUN_APPS_IN_OWN_THREAD */

--- a/arch/arm/nrf5x/startup.c
+++ b/arch/arm/nrf5x/startup.c
@@ -29,10 +29,64 @@ void Reset_Handler(void);
 
 static void generic_isr_handler(void);
 
+typedef struct __attribute__((packed)) ContextStateFrame {
+  uint32_t r0;
+  uint32_t r1;
+  uint32_t r2;
+  uint32_t r3;
+  uint32_t r12;
+  uint32_t lr;
+  uint32_t return_address;
+  uint32_t xpsr;
+} sContextStateFrame;
+
+__attribute__((optimize("O0")))
+void prvGetRegistersFromStack(sContextStateFrame *frame)
+{ 
+  printf("***** Hardware exception *****\n");
+  printf("R0:%x "
+         "R1:%x "
+         "R2:%x "
+         "R3:%x "
+         "R12:%x "
+         "LR:%x "
+         "RET_ADDR:%x "
+         "XPSR:%x \n",
+         frame->r0,
+         frame->r1,
+         frame->r2,
+         frame->r3,
+         frame->r12,
+         frame->lr,
+         frame->return_address,
+         frame->xpsr);
+
+  printf("***** Running Task *****\n");
+  struct tcb_s *tcb = sched_get_current_task();
+
+  printf("Task name: %s\n"
+         "addr:%x "
+         "SP:%x "
+         " TOP:%x BASE:%x\n",
+         tcb->task_name == NULL ? "[Noname]" : tcb->task_name,
+         tcb,
+         tcb->sp,
+         tcb->stack_ptr_top,
+         tcb->stack_ptr_base);
+
+  __asm volatile("bkpt 1");
+}
+
 /* The fault handler implementation calls a function called
 prvGetRegistersFromStack(). */
+__attribute__((optimize("O0")))
 static void HardFault_Handler(void)
-{
+{ 
+  __asm volatile("tst lr, #4 \n"
+                  "ite eq \n"
+                  "mrseq r0, msp \n"
+                  "mrsne r0, psp \n"
+                  "b prvGetRegistersFromStack \n");
 }
 
 /* Flash based ISR vector */

--- a/sched/include/scheduler.h
+++ b/sched/include/scheduler.h
@@ -26,6 +26,10 @@
 
 #define MCU_CONTEXT_SIZE                      (8)
 
+/* Task name */
+
+#define CONFIG_TASK_NAME_LEN                  (32)
+
 /* The interrupt callback type */
 
 typedef void (* irq_cb)(void);
@@ -63,11 +67,16 @@ typedef struct tcb_s {
   sem_t *waiting_tcb_sema;
   struct list_head opened_resource;
   uint32_t curr_resource_opened;
+  const char task_name[CONFIG_TASK_NAME_LEN];
 } tcb_t __attribute__((aligned(8)));
 
 int sched_init(void);
 
-int sched_create_task(int (*task_entry_point)(int argc, char **argv), uint32_t stack_size, int argc, char **argv);
+int sched_create_task(int (*task_entry_point)(int argc, char **argv),
+                      uint32_t stack_size,
+                      int argc,
+                      char **argv,
+                      const char *task_name);
 
 void sched_run(void);
 

--- a/sched/os_appstart.c
+++ b/sched/os_appstart.c
@@ -10,7 +10,7 @@
 void os_appstart(void)
 {
 #ifdef CONFIG_CONSOLE_APP
-  sched_create_task(console_main, CONFIG_CONSOLE_STACK_SIZE, 0, NULL);
+  sched_create_task(console_main, CONFIG_CONSOLE_STACK_SIZE, 0, NULL, "Console");
 #endif
 
   while(1)

--- a/utils/worker.c
+++ b/utils/worker.c
@@ -149,7 +149,8 @@ int worker_create(int priority, const char *name)
   int ret = sched_create_task(worker_main,
                               CONFIG_WORKER_STACK_SIZE,
                               1,
-                              (char **)new_worker);
+                              (char **)new_worker,
+                              "Worker");
   if (ret != 0) {
     ret = -EINVAL;
     goto free_with_worker;


### PR DESCRIPTION
 ## Summary of changes

Add hardfault handler implementation and fump registry and task
information on the serial console.

Example:
```
root:#/>***** Hardware exception *****
R0:2000248C R1:2000139C R2:2000005C R3:2 R12:1 LR:912D RET_ADDR:61F2 XPSR:200000A4
***** Running Task *****
Task name: Console
addr:20001C98 SP:200022C4  TOP:20002504 BASE:20001D04
```
Signed-off-by: Sebastian Ene <sebastian.ene07@gmail.com>