### PR TITLE
Bugfix sim target crash (unaligned stack on OSX)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ SRC_DIRS += sched s_alloc utils apps lib drivers
 TMP_LIB=libtmp.a
 CONFIG_HOST_OS="$(shell uname)"
 ifeq ($(CONFIG_HOST_OS),"Darwin")
+CFLAGS+= -mstack-alignment=16 -mno-sse -mstackrealign
 LDUNEXPORTSYMBOLS ?= -unexported_symbols_list ../$(CONFIG_HOST_OS)-names.dat
 EXTRALINK ?=
 else

--- a/arch/sim/sim/board_initialize.c
+++ b/arch/sim/sim/board_initialize.c
@@ -50,7 +50,7 @@
 
 /* The stack alignment in bytes */
 
-#define STACK_ALIGNMENT               (8)
+#define STACK_ALIGNMENT               (64)
 #define ALIGN_STACK_DOWN(addr)((void *)((unsigned long)(addr) & ~(STACK_ALIGNMENT - 1)))
 
 /****************************************************************************

--- a/arch/sim/sim/context_switch.s
+++ b/arch/sim/sim/context_switch.s
@@ -11,14 +11,13 @@
  *  cpu_savecontext
  *
  * Description:
- *  Dump the registers on the stack and update the stack pointer from the TCB. 
+ *  Dump the registers in the argument received as buffer.
  *
  * Input Arguments:
- *  sp - the pointer to the location of the 'sp' member from the tcb_t
- *       (in RDI register)
+ *  mcu_context - the pointer to the CPU context
  *
  * Return Value:
- *  If we return on the normal path (after we stacked all the registers)
+ *  If we return on the normal path (after we saved all the registers)
  *  we return 0. If we return from this function because cpu_contextrestore
  *  was called we return 1.
  *
@@ -28,21 +27,19 @@ _cpu_savecontext:
 #else
 cpu_savecontext:
 #endif
-  pop %rsi		/* Save the return value in RSI */
-  push %rsi		/* Push back the return value to restore the calling stack */
-  push %rbp		/* Push the old frame pointer */
-  movq %rbp, %rax	/* Save the old frame pointer in RAX to push it on the stack for context switch save */
-  movq %rsp, %rbp	/* Save the stack pointer on the RBP to create the stack frame for this function */
-  push %rbx		/* 1. RBX */
-  push %rax		/* 2. in RAX we have the old frame pointer RBP */
-  xorl %eax,%eax	/* Zero out EAX for the normal return path */
-  push %r12		/* 3. R12 */
-  push %r13		/* 4. R13 */
-  push %r14		/* 5. R14 */
-  push %r15		/* 6. R15 */
-  push %rsi		/* 7. in RSI we keep the return address, push it on the stack for context switch save */
-  movq %rsp, (%rdi)	/* Save the address of the stack pointer (after stacking) in the paramter received as argument */
-  leaveq		/* Restore the old frame pointer */
+  pop %rsi			/* Save the return value in RSI */
+  push %rsi			/* Push back the return value to restore the calling stack */
+  movq %rsi, (8 * 6)(%rdi)	/* Save the PC */
+  push %rbp			/* Push the old frame pointer */
+  movq %rbp, (8 * 1)(%rdi)	/* 1.RBP */ 
+  movq %rsp, %rbp		/* Save the stack pointer on the RBP to create the stack frame for this function */
+  movq %rbx, (%rdi) 		/* 0. RBX */
+  xorl %eax,%eax		/* Zero out EAX for the normal return path */
+  movq %r12, (8 * 2)(%rdi)	/* 2. R12 */
+  movq %r13, (8 * 3)(%rdi)	/* 4. R13 */
+  movq %r14, (8 * 4)(%rdi)	/* 5. R14 */
+  movq %r15, (8 * 5)(%rdi)	/* 6. R15 */
+  leaveq			/* Restore the old frame pointer */
   ret
 
   .align 4
@@ -57,10 +54,11 @@ cpu_savecontext:
  *  cpu_restorecontext
  *
  * Description:
- *  Recreate the task context by popping the registers from the stack. 
+ *  Recreate the task context by copying the register contents from the
+ *  parameter received as argument. 
  *
  * Input Arguments:
- *  sp - the pointer to the stack (in R0 register)
+ *  mcu_context - the pointer to the CPU context)
  *
  ************************************************************************/
 #ifdef __APPLE__
@@ -68,13 +66,13 @@ _cpu_restorecontext:
 #else
 cpu_restorecontext:
 #endif
-  mov $1, %eax		/* Store an immediate value of 1 in EAX for the return value */
-  movq %rdi, %rsp	/* Switch stacks to the one received as argument */
-  pop %rsi		/* 7. Get the return address in RSI */
-  pop %r15		/* 6. R15 */
-  pop %r14		/* 5. R14 */
-  pop %r13		/* 4. R13 */
-  pop %r12		/* 3. R12 */
-  pop %rbp		/* Restore the old frame pointer ( the function that initially called cpu_savecontext ) */
-  pop %rbx		/* 1. RBX */
+  mov $1, %eax		        /* Store an immediate value of 1 in EAX for the return value */
+  movq (8 * 7)(%rdi), %rsp	/* Switch stacks to the one received as argument */
+  movq (8 * 6)(%rdi), %rsi  /* 7. Get the return address in RSI */
+  movq (8 * 5)(%rdi), %r15  /* 6. R15 */
+  movq (8 * 4)(%rdi), %r14  /* 5. R14 */
+  movq (8 * 3)(%rdi), %r13  /* 4. R13 */
+  movq (8 * 2)(%rdi), %r12  /* 3. R12 */
+  movq (8 * 1)(%rdi), %rbp  /* Restore the old frame pointer ( the function that initially called cpu_savecontext ) */
+  movq (%rdi), %rbx		/* 1. RBX */
   jmp *%rsi		/* Jump to the return value from RSI */

--- a/arch/sim/sim/context_switch.s
+++ b/arch/sim/sim/context_switch.s
@@ -1,5 +1,5 @@
   .text
-  .align 4
+  .align 16
 #ifdef __APPLE__
   .globl _cpu_savecontext
 #else
@@ -27,22 +27,23 @@ _cpu_savecontext:
 #else
 cpu_savecontext:
 #endif
-  pop %rsi			/* Save the return value in RSI */
-  push %rsi			/* Push back the return value to restore the calling stack */
+  pop %rsi			            /* Save the return value in RSI */
+  movq %rsp, (8 * 7)(%rdi)  /* Save the SP (before call)    */
+  push %rsi			            /* Push back the return value to restore the calling stack */
   movq %rsi, (8 * 6)(%rdi)	/* Save the PC */
-  push %rbp			/* Push the old frame pointer */
+  push %rbp			            /* Push the old frame pointer */
   movq %rbp, (8 * 1)(%rdi)	/* 1.RBP */ 
-  movq %rsp, %rbp		/* Save the stack pointer on the RBP to create the stack frame for this function */
-  movq %rbx, (%rdi) 		/* 0. RBX */
-  xorl %eax,%eax		/* Zero out EAX for the normal return path */
+  movq %rsp, %rbp		        /* Save the stack pointer on the RBP to create the stack frame for this function */
+  movq %rbx, (%rdi) 		    /* 0. RBX */
+  xorl %eax,%eax		        /* Zero out EAX for the normal return path */
   movq %r12, (8 * 2)(%rdi)	/* 2. R12 */
   movq %r13, (8 * 3)(%rdi)	/* 4. R13 */
   movq %r14, (8 * 4)(%rdi)	/* 5. R14 */
   movq %r15, (8 * 5)(%rdi)	/* 6. R15 */
   leaveq			/* Restore the old frame pointer */
-  ret
+  retq
 
-  .align 4
+  .align 16
 #ifdef __APPLE__ 
   .globl _cpu_restorecontext
 #else
@@ -66,13 +67,13 @@ _cpu_restorecontext:
 #else
 cpu_restorecontext:
 #endif
-  mov $1, %eax		        /* Store an immediate value of 1 in EAX for the return value */
-  movq (8 * 7)(%rdi), %rsp	/* Switch stacks to the one received as argument */
-  movq (8 * 6)(%rdi), %rsi  /* 7. Get the return address in RSI */
-  movq (8 * 5)(%rdi), %r15  /* 6. R15 */
-  movq (8 * 4)(%rdi), %r14  /* 5. R14 */
-  movq (8 * 3)(%rdi), %r13  /* 4. R13 */
-  movq (8 * 2)(%rdi), %r12  /* 3. R12 */
-  movq (8 * 1)(%rdi), %rbp  /* Restore the old frame pointer ( the function that initially called cpu_savecontext ) */
+  mov $1, %eax		            /* Store an immediate value of 1 in EAX for the return value */
+  movq (8 * 7)(%rdi), %rsp	  /* Switch stacks to the one received as argument */
+  movq (8 * 6)(%rdi), %rsi  	/* 7. Get the return address in RSI */
+  movq (8 * 5)(%rdi), %r15  	/* 6. R15 */
+  movq (8 * 4)(%rdi), %r14  	/* 5. R14 */
+  movq (8 * 3)(%rdi), %r13  	/* 4. R13 */
+  movq (8 * 2)(%rdi), %r12  	/* 3. R12 */
+  movq (8 * 1)(%rdi), %rbp  	/* Restore the old frame pointer ( the function that initially called cpu_savecontext ) */
   movq (%rdi), %rbx		/* 1. RBX */
   jmp *%rsi		/* Jump to the return value from RSI */

--- a/arch/sim/sim/include/board.h
+++ b/arch/sim/sim/include/board.h
@@ -27,9 +27,9 @@ void cpu_destroytask(tcb_t *tcb);
  * CPU context management functions
  ****************************************************************************/
 
-int cpu_savecontext(void **task_sp);
+int cpu_savecontext(void *mcu_context);
 
-void cpu_restorecontext(void *task_sp);
+void cpu_restorecontext(void *mcu_context);
 
 /****************************************************************************
  * CPU interrupt management functions

--- a/config/README.md
+++ b/config/README.md
@@ -29,21 +29,20 @@ Description:
 
 ### CPU context management functions
 
-```int cpu_savecontext(void **tcb_sp)```
+```int cpu_savecontext(void *mcu_context)```
 
 Description:
 
-	Save the current context on the stack and return "0". Update the
-	task pointer from the TCB with the new value after register stacking.
+	Save the current context in the 'mcu_context' and return "0". 
 	When we return from this function because of a cpu_restorecontext(..)
 	call, the value "1" is returned.
 
-```void cpu_restorecontext(void *tcb_sp)```
+```void cpu_restorecontext(void *mcu_context)```
 
 Description:
 
-	Restore the task context from the stack and start executing from the last
-	stacked PC. This function does not return.
+	Restore the task context from 'mcu_context' and start executing from
+	the last saved PC. This function does not return.
 
 ### CPU interrupt management functions
 

--- a/sched/include/scheduler.h
+++ b/sched/include/scheduler.h
@@ -62,7 +62,7 @@ typedef struct tcb_s {
   struct list_head opened_resource; /* Opened task resources     */
   uint32_t curr_resource_opened;    /* Num of opened resources   */
   const char task_name[CONFIG_TASK_NAME_LEN];
-} tcb_t __attribute__((aligned(8)));
+} tcb_t __attribute__((aligned(16)));
 
 /****************************************************************************
  * Public Scheduler Functions 

--- a/sched/scheduler.c
+++ b/sched/scheduler.c
@@ -414,7 +414,7 @@ void sched_run(void)
 
     /* Set the context to the new task */
 
-    cpu_restorecontext(current_task->sp);
+    cpu_restorecontext(current_task->mcu_context);
     return;
   }
 
@@ -510,7 +510,7 @@ sched_preempt_task(tcb_t *to_preempt_tcb)
 
   /* Save the current context in the task that needs to be preempted */
 
-  if (cpu_savecontext(&to_preempt_tcb->sp))
+  if (cpu_savecontext(to_preempt_tcb->mcu_context))
   {
     SCHED_DEBUG_INFO("%s restored context\n", to_preempt_tcb->task_name);
     cpu_enableint(irq_state);
@@ -543,7 +543,7 @@ sched_preempt_task(tcb_t *to_preempt_tcb)
 
     /* Switch the context to the new task */
 
-    cpu_restorecontext(new_tcb->sp);
+    cpu_restorecontext(new_tcb->mcu_context);
   }
 
   cpu_enableint(irq_state);                                                                         


### PR DESCRIPTION
Ticked issue number : #73 

## Summary of Changes

Save the context in the mcu_buffer from the TCB. Update board interface to reflect this change.
Use a flag for clang to force the stack re-align on each function call (to 16 bytes) to support SSE instructions.

Signed-off-by: Sebastian Ene <sebastian.ene07@gmail.com>