### PR TITLE
Add support for the RpiPico uart driver and fix argument passing 

### DIFF
--- a/arch/arm/rpipico/Makefile
+++ b/arch/arm/rpipico/Makefile
@@ -8,7 +8,7 @@ ARCH_FLAGS:=${CFLAGS} -I$(TOPDIR)/include\
 											-I$(TOPDIR)/sched/include\
 											-I$(TOPDIR)/$(PICO_SDK)/src/host/hardware_uart/include/\
 											-I$(TOPDIR)/$(PICO_SDK)/src/common/pico_base/include/\
-											-I$(TOPDIR)/$(PICO_SDK)/generated/pico_base/\
+											-I$(TOPDIR)/$(PICO_SDK)/../build/generated/pico_base/\
 											-I$(TOPDIR)/$(PICO_SDK)/src/rp2_common/pico_platform/include/\
 											-I$(TOPDIR)/$(PICO_SDK)/src/host/pico_platform/include/\
 											-I$(TOPDIR)/$(PICO_SDK)/src/rp2040/hardware_structs/include/\

--- a/arch/arm/rpipico/board_initialize.c
+++ b/arch/arm/rpipico/board_initialize.c
@@ -24,6 +24,8 @@
  * Public Functions
  ****************************************************************************/
 
+struct uart_lower_s *uart_upper_init(size_t *uart_num);
+
 /*
  * board_init - initialize the board resources
  *
@@ -31,7 +33,10 @@
  */
 void board_init(void)
 {
+  size_t uart_num = 0;
+
   bsp_gpio_led_init();
+  uart_upper_init(&uart_num);
 }
 
 /*

--- a/arch/arm/rpipico/bsp.c
+++ b/arch/arm/rpipico/bsp.c
@@ -6,17 +6,23 @@
 #include "hardware/resets.h"
 #include "hardware/regs/resets.h"
 #include "hardware/uart.h"
+
 #include "bsp.h"
+#include "hardware/irq.h"
 
 /****************************************************************************
  * Preprocessor Definitions
  ****************************************************************************/
 
+#define DATA_BITS 8
+#define STOP_BITS 1
+#define PARITY    UART_PARITY_NONE
+
 #define CONSOLE_UART_ID             uart0
 #define CONSOLE_BAUD_RATE           115200
 
-#define CONSOLE_UART_TX_PIN         0
-#define CONSOLE_UART_RX_PIN         1
+#define CONSOLE_UART_TX_PIN         12
+#define CONSOLE_UART_RX_PIN         13
 
 /****************************************************************************
  * External symbols
@@ -58,6 +64,34 @@ void bsp_serial_console_init(void)
   // Set datasheet for more information on function select
   gpio_set_function(CONSOLE_UART_TX_PIN, GPIO_FUNC_UART);
   gpio_set_function(CONSOLE_UART_RX_PIN, GPIO_FUNC_UART);
+}
+
+static volatile void (*g_uart0_notify_received)(uint8_t);
+
+void __attribute__((optimize("O0"))) rpipico_uart0_irq(void)
+{
+  while (uart_is_readable(CONSOLE_UART_ID)) {
+    uint8_t ch = uart_getc(CONSOLE_UART_ID);
+    if (g_uart0_notify_received != NULL) {
+      g_uart0_notify_received(ch);
+    }
+  }
+}
+
+int bsp_serial_console_attach_irq(void *irq_cb(uint8_t))
+{
+  int UART_IRQ = CONSOLE_UART_ID == uart0 ? UART0_IRQ : UART1_IRQ;
+
+  uart_set_baudrate(CONSOLE_UART_ID, 115200);
+  uart_set_hw_flow(CONSOLE_UART_ID, false, false);
+  uart_set_format(CONSOLE_UART_ID, DATA_BITS, STOP_BITS, PARITY);
+  uart_set_fifo_enabled(CONSOLE_UART_ID, false);
+
+  g_uart0_notify_received = irq_cb;
+  irq_set_enabled(UART_IRQ, true);
+  uart_set_irq_enables(CONSOLE_UART_ID, true, false);
+
+  return UART_IRQ;
 }
 
 void bsp_serial_console_putc(int c)

--- a/arch/arm/rpipico/bsp.h
+++ b/arch/arm/rpipico/bsp.h
@@ -1,20 +1,9 @@
 #ifndef __ARCH_ARM_RPIPICO_BSP_H
 #define __ARCH_ARM_RPIPICO_BSP_H
 
-#define REG_R0                (0)
-#define REG_R1                (1)
-#define REG_R2                (2)
-#define REG_R3                (3)
-#define REG_R4                (4)
-#define REG_R5                (5)
-#define REG_R6                (6)
-#define REG_R7                (7)
-#define REG_R8                (8)
-#define REG_R9                (9)
+#define REG_R0                (10)
+#define REG_R1                (9)
 
-#define REG_R10               (10)
-#define REG_R11               (11)
-#define REG_R12               (12)
 #define REG_SP                (13)
 #define REG_LR                (14)
 #define REG_PC                (15)

--- a/arch/arm/rpipico/context_switch.s
+++ b/arch/arm/rpipico/context_switch.s
@@ -96,10 +96,12 @@ cpu_restorecontext:
 
     ldr r1, [r0, #56]         // Get the LR
     mov lr, r1
-    ldr r1, [r0, #60]         // Get the PC address in R1
+    ldr r3, [r0, #60]         // Get the PC address in R1
     ldr r2, [r0, #64]         // Get the XPSR address in R2
+    ldr r1, [r0, #36]         // Get the R1
+    ldr r0, [r0, #40]         // Get the R0
     msr psr, r2              // Restore the XPSR from R2
-    mov pc, r1                // Jump to the last PC from R1
+    mov pc, r3                // Jump to the last PC from R1
 
 .size cpu_restorecontext, .-cpu_restorecontext
 .end


### PR DESCRIPTION


## Summary of changes ##

- add support for the UART driver using the pico-sdk. Route the UART interrupts from Calypso OS to the pico-sdk
- fix argument passing during task creation (in R0 we have the number of arguments, in R1 we keep the arguments)

Signed-off-by: dedsecn00b <dedsecn00b@gmail.com>